### PR TITLE
Load a PNG file and print out the image details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+sc4texture

--- a/sc4texture.go
+++ b/sc4texture.go
@@ -1,7 +1,26 @@
 package main
 
-import "fmt"
+import (
+  "flag"
+  "os"
+  "fmt"
+  "image/png"
+)
 
 func main() {
-    fmt.Printf("SC4Texture Tool\n")
+  filename := flag.String("in", "", "The name of the file to load.")
+  flag.Parse()
+
+  file, e := os.Open(*filename)
+  if e != nil {
+    fmt.Printf("Failed to open file %s. Error: %s\n", *filename, e)
+  }
+  defer file.Close()
+
+  image, e := png.Decode(file)
+  if e != nil {
+    fmt.Printf("Failed to decode PNG image. Error: %s\n", e)
+  }
+
+  fmt.Printf("Image details: %s\n", image.Bounds().String())
 }


### PR DESCRIPTION
This PR starts building the SC4Texture application.  It adds the ability to specify a PNG image filename as an argument.  That filename is loaded and decoded into an image.Image instance and the details are printed to the standard output stream.
